### PR TITLE
Autodetect filename and line number where log() was called

### DIFF
--- a/graylog.js
+++ b/graylog.js
@@ -106,7 +106,7 @@ function retrieveFileInfo(opts){
 		match;
 
 	for(var i=0, len = stack.length; i<len; i++){
-		if((match = stack[i].match(/^\s*at\s[^\(]\(([^\):]+):(\d+):\d+\)/))){
+		if((match = stack[i].match(/^\s*at\s[^\(]+\(([^\):]+):(\d+):\d+\)/))){
 			if(__filename.substr(-match[1].length) == match[1]){
 				continue;
 			}


### PR DESCRIPTION
I added automatic detection for filename and line number where log() was called - the patch adds 'file' and 'line' properties to opts if these values are not yet set. The data is detected from an Error stack.
