### PR TITLE
Fixed issue with LOG_EMERG

### DIFF
--- a/graylog.js
+++ b/graylog.js
@@ -60,7 +60,7 @@ function log(shortMessage, a, b) {
 	opts.version="1.0";
 	opts.timestamp = opts.timestamp || new Date().getTime()/1000 >> 0;
 	opts.host = opts.host || GLOBAL.graylogHostname;
-	opts.level = opts.level || GLOBAL.LOG_INFO;
+	opts.level = opts.level !== undefined ? opts.level : GLOBAL.LOG_INFO;
 	opts.facility = opts.facility || GLOBAL.graylogFacility;
 
 	if (opts.stack) {


### PR DESCRIPTION
Hey mate, great plugin - very handy ~ i have been trying to implement chunking but until then i have fixed this problem - it has been annoying me in a project that im working on where we use this.

The code that this replaces was short sighted, if you used LOG_EMERG (0) with your old code then it is overridden and turned into LOG_INFO

var a = 0;
var b = a || 6;

b === 6
