### PR TITLE
add spec version support

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ You can set <code>GLOBAL.graylogChunkSize</code> to the maximum allowed bytes fo
 
 You can set <code>GLOBAL.additionalFields</code> for any properties that would like to include on every log message.
 
+You can set <code>GLOBAL.gelfversion</code> for initialize gelf spec version by default is set to 1.1. There way can be used as option of additionalFields use 
+
+
 ````
 GLOBAL.additionalFields = {
     _environment: "Dev",

--- a/graylog.js
+++ b/graylog.js
@@ -23,6 +23,7 @@ GLOBAL.graylogFacility = 'Node.js';
 GLOBAL.graylogSequence = 0;
 GLOBAL.graylogChunkSize = 1100; // 8192 is the maximum
 GLOBAL.graylogAdditionalFields = {};
+GLOBAL.gelfversion = 1.1
 
 function generateMessageId() {
 	return '' + (Date.now() + Math.floor(Math.random()*10000));
@@ -118,7 +119,7 @@ function log(shortMessage, a, b) {
 		opts = a || {};
 	}
 
-	opts.version="1.0";
+	opts.version=GLOBAL.gelfversion;
 	opts.timestamp = opts.timestamp || new Date().getTime()/1000 >> 0;
 	opts.host = opts.host || GLOBAL.graylogHostname;
 	opts.level = opts.level !== undefined ? opts.level : GLOBAL.LOG_INFO;


### PR DESCRIPTION
With graylog server new version spec 1.0 is not supported. I've add a simple parameter to initalize di spec in alternative to additionalFields
